### PR TITLE
doc: use `opts` type in the suggested lazy.nvim setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you find any bugs please submit an issue.
 
 TSsorter supports the latest stable release of Neovim, currently version `0.10.1.` Other versions may work but are not guaranteed.
 
-This plugin depends on Treesitter so make sure to install the parser for the filetype you are trying to configure!  
+This plugin depends on Treesitter so make sure to install the parser for the filetype you are trying to configure!
 
 You can install using your favorite package manager, here are a few examples:
 
@@ -24,12 +24,12 @@ You can install using your favorite package manager, here are a few examples:
 {
     'mtrajano/tssorter.nvim',
     version = '*', -- latest stable version, use `main` to keep up with the latest changes
-    config = function()
-        require('tssorter').setup({
-            -- leave empty for the default config or define your own sortables in here. They will add, rather than
-            -- replace, the defaults for the given filetype
-        })
-    end
+    ---@module "tssorter"
+    ---@type TssorterOpts
+    opts = {
+        -- leave empty for the default config or define your own sortables in here. They will add, rather than
+        -- replace, the defaults for the given filetype
+    }
 }
 ```
 
@@ -39,11 +39,11 @@ You can install using your favorite package manager, here are a few examples:
 use {
     'mtrajano/tssorter.nvim',
     tag = '*', -- latest stable version, use `main` to keep up with the latest changes
-    config = function() 
+    config = function()
         require('tssorter').setup({
             -- leave empty for the default config or define your own sortables in here. They will add, rather than
             -- replace, the defaults for the given filetype
-        }) 
+        })
     end
   }
 ```
@@ -97,7 +97,7 @@ Here is an explanation of what each key means:
 
 ## Lua API
 
-By default simply calling `sort` should sort the nearest sortable under the cursor. 
+By default simply calling `sort` should sort the nearest sortable under the cursor.
 
 ```lua
 require('tssorter').sort()
@@ -190,5 +190,5 @@ itself!
 
 # Contribution
 
-See an interesting use case you don't see mentioned here or that is not yet implemented? Create an issue or submit a pr! 
+See an interesting use case you don't see mentioned here or that is not yet implemented? Create an issue or submit a pr!
 Any help adding documentation would also be appreciated.

--- a/lua/tssorter/config.lua
+++ b/lua/tssorter/config.lua
@@ -1,22 +1,22 @@
 local M = {}
 
----@class Config
----@field sortables? SortableCfg
----@field logger? LoggerCfg
-
----@alias SortableCfg { [string]: SortableList }
----@alias SortableList { [string]: SortableOpts }
-
 ---@class SortableOpts
 ---@field node? string|string[]
 ---@field ordinal? string|string[]
 ---@field order_by? function
 
+---@alias SortableCfg { [string]: SortableList }
+---@alias SortableList { [string]: SortableOpts }
+
 ---@class LoggerCfg
 ---@field level? number
 ---@field outfile? string?
 
----@type Config
+---@class TssorterOpts
+---@field sortables? SortableCfg
+---@field logger? LoggerCfg
+
+---@type TssorterOpts
 -- TODO: add any more defaults that would make sense having out of the box
 M.default_config = {
   sortables = {
@@ -122,7 +122,7 @@ M.default_config = {
   },
 }
 
----@param opts Config?
+---@param opts TssorterOpts?
 M.setup = function(opts)
   opts = opts or {}
   -- FIX: what happens if the sortable the user wants to specify conflicts with one of the sortables? We need to give a
@@ -131,7 +131,7 @@ M.setup = function(opts)
   return M.default_config
 end
 
----@return Config
+---@return TssorterOpts
 M.get_config = function()
   return M.default_config
 end

--- a/lua/tssorter/init.lua
+++ b/lua/tssorter/init.lua
@@ -5,7 +5,7 @@ local command = require('tssorter.command')
 
 local M = {}
 
----@param opts Config?
+---@param opts TssorterOpts?
 M.setup = function(opts)
   opts = config.setup(opts)
 


### PR DESCRIPTION
Going to be useful for people using lazydev.nvim / neodev.nvim.

I renamed the type so it wouldn't get confused with the many other generic `Config` types suggested by the lsp.
